### PR TITLE
Env are now downloaded through PL and not from sandbox directly

### DIFF
--- a/server/serverpl/filebrowser/urls.py
+++ b/server/serverpl/filebrowser/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path(r'save_edit/', views.save_edit_receiver, name='save_edit_receiver'),
     path(r'edit_file/', views.edit_receiver, name='edit_receiver'),
     path(r'preview_pl/', views.preview_pl, name='preview_pl'),
+    path(r'download/env/<str:envid>/', views.download_env, name='dlenv'),
     path(r'<path:path>/opt/', views.apply_option, name='apply_option'),
     path(r'<path:path>/', views.index, name='index'),
 ]

--- a/server/serverpl/playexo/templates/playexo/preview.html
+++ b/server/serverpl/playexo/templates/playexo/preview.html
@@ -28,7 +28,7 @@
             <button id="submit_button" class="btn btn-primary">
                 <i class="fas fa-check"></i> Valider
             </button>
-            <a id="download_env_button" type="button" class="btn btn-secondary" href="{{sandbox_url__}}env/{{id__}}/" download>
+            <a id="download_env_button" type="button" class="btn btn-secondary" href="{% url 'filebrowser:dlenv' id__ %}" download>
                 <i class="fas fa-download"></i> Télécharger l'Environnement
             </a>
         </center>


### PR DESCRIPTION
Since the Sandboxes are not supposed to be visible on the internet, direct download wasn't working. The env is now downloaded to PL, which redirect it to the user.

Basically :
* Before `user <---env--- sandbox`
* Now `user <---env--- PL <---env--- sandbox`

See #122 

Bonus: code formatting on server/serverpl/filebrowser/views.py